### PR TITLE
Fix an issue with decoding non-ASCIIs in QUERY_STRING.

### DIFF
--- a/Network/CGI.hs
+++ b/Network/CGI.hs
@@ -136,7 +136,7 @@ runCGI f = do env <- getCGIVars
 
 -- | Output a 'String'. The output is assumed to be text\/html, encoded using
 --   ISO-8859-1. To change this, set the Content-type header using
---   'setHeader'.
+--   'setHeader' and perhaps use @outputFPS@ instead.
 output :: MonadCGI m =>
           String        -- ^ The string to output.
        -> m CGIResult

--- a/Network/CGI/Protocol.hs
+++ b/Network/CGI/Protocol.hs
@@ -42,6 +42,7 @@ import System.Environment (getEnvironment)
 import System.IO (Handle, hPutStrLn, stderr, hFlush, hSetBinaryMode)
 
 import qualified Data.ByteString.Lazy.Char8 as BS
+import qualified Data.ByteString.Lazy.UTF8 as BU
 import Data.ByteString.Lazy.Char8 (ByteString)
 
 #if MIN_VERSION_base(4,7,0)
@@ -144,7 +145,7 @@ formatResponse :: ByteString -> Headers -> ByteString
 formatResponse c hs =
     -- NOTE: we use CRLF since lighttpd mod_fastcgi can't handle
     -- just LF if there are CRs in the content.
-    unlinesCrLf ([BS.pack (n++": "++v) | (HeaderName n,v) <- hs]
+    unlinesCrLf ([BU.fromString (n++": "++v) | (HeaderName n,v) <- hs]
                 ++ [BS.empty,c])
   where unlinesCrLf = BS.concat . intersperse (BS.pack "\r\n")
 
@@ -169,7 +170,7 @@ decodeInput env inp =
 
 -- | Builds an 'Input' object for a simple value.
 simpleInput :: String -> Input
-simpleInput v = Input { inputValue = BS.pack v,
+simpleInput v = Input { inputValue = BU.fromString v,
                         inputFilename = Nothing,
                         inputContentType = defaultInputType }
 
@@ -206,6 +207,13 @@ queryInput :: [(String,String)] -- ^ CGI environment variables.
 queryInput env = formInput $ lookupOrNil "QUERY_STRING" env
 
 -- | Decodes application\/x-www-form-urlencoded inputs.
+--
+-- Example:
+--
+-- >>> map (\(x,y)->(x,inputValue y)) $ formInput "term=%CE%BBx.x"
+-- [("term","\206\187x.x")]
+--
+-- We can see that the result matches the input.
 formInput :: String
           -> [(String,Input)] -- ^ Input variables and values.
 formInput qs = [(n, simpleInput v) | (n,v) <- formDecode qs]

--- a/cgi.cabal
+++ b/cgi.cabal
@@ -47,6 +47,7 @@ Library
     exceptions < 0.9,
     xhtml >= 3000.0.0 && < 3000.3,
     bytestring < 0.11,
+    utf8-string == 1.*,
     base >= 4.5 && < 5,
     old-time < 1.2,
     old-locale < 1.1,


### PR DESCRIPTION
Function unEscapeString in recent network packages will decode urlencoded byte sequences using UTF-8 decoding, so the result from urlDecode will be Unicode strings instead of raw bytes. This patch is to fix issues caused by this.