### PR TITLE
Stackify, relax version bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+stack.yaml
+.stack-work/

--- a/cgi.cabal
+++ b/cgi.cabal
@@ -1,5 +1,5 @@
 Name: cgi
-Version: 3001.3.0.3
+Version: 3001.4.0.0
 Copyright: Bjorn Bringert, John Chee, Andy Gill, Anders Kaseorg,
            Ian Lynagh, Erik Meijer, Sven Panne, Jeremy Shaw
 Category: Network

--- a/cgi.cabal
+++ b/cgi.cabal
@@ -44,11 +44,11 @@ Library
 
   Build-depends:
     parsec >= 2.0 && < 3.2,
-    exceptions < 0.9,
+    exceptions < 0.11,
     xhtml >= 3000.0.0 && < 3000.3,
     bytestring < 0.11,
     base >= 4.5 && < 5,
-    time >= 1.5 && < 1.7,
+    time >= 1.5 && < 1.9,
     containers < 0.6,
     multipart >= 0.1.2 && < 0.2
   If flag(network-uri)

--- a/stack-12.0.yaml
+++ b/stack-12.0.yaml
@@ -1,0 +1,1 @@
+resolver: lts-12.0


### PR DESCRIPTION
This allows for using `cgi` with `lts-12.0`