### PR TITLE
Don't re-implement error handling functions from 'exceptions'.

### DIFF
--- a/Network/CGI.hs
+++ b/Network/CGI.hs
@@ -95,7 +95,7 @@ module Network.CGI (
 
 import Control.Exception (Exception(..), SomeException, ErrorCall(..))
 import Control.Monad (liftM)
-import Control.Monad.Catch (MonadCatch)
+import Control.Monad.Catch (MonadCatch(..), handle)
 import Control.Monad.Trans (MonadIO, liftIO)
 import Data.Char (toUpper)
 import Data.List (intersperse, sort, group)
@@ -176,7 +176,7 @@ redirect url = do setHeader "Location" url
 -- > main :: IO ()
 -- > main = runCGI (handleErrors cgiMain)
 handleErrors :: (MonadCGI m, MonadCatch m, MonadIO m) => m CGIResult -> m CGIResult
-handleErrors = flip catchCGI outputException
+handleErrors = handle outputException
 
 --
 -- * Error output


### PR DESCRIPTION
Network.CGI.Monad exports throwCGI, catchCGI, tryCGI, and handleExceptionCGI,
all of which are trivial aliases for the methods provided by our MonadCatch
instance. Exporting those functions serves no obvious benefit. Users of our
code should rather use the functions from the MonadCatch (or MonadError) class
directly to make their code more generic.

As neat side effect of this change is that our code no longer triggers warnings
about redundant constraints.