### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/src/Network/CGI/Monad.hs
+++ b/src/Network/CGI/Monad.hs
@@ -59,7 +59,6 @@ instance (Applicative m) => Applicative (CGIT m) where
 
 instance Monad m => Monad (CGIT m) where
     c >>= f = CGIT (unCGIT c >>= unCGIT . f)
-    return = CGIT . return
 
 instance MonadFail m => MonadFail (CGIT m) where
     fail = CGIT . fail


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return